### PR TITLE
Re-added syncing for htmlReport as reports were not being completed (end...

### DIFF
--- a/tasks/qunit.js
+++ b/tasks/qunit.js
@@ -92,7 +92,7 @@ module.exports = function(grunt) {
 
       // check if a html report should be generated
       if (coverageOptions.htmlReport) {
-        Report.create('html', {dir: coverageOptions.htmlReport}).writeReport(collector);
+        Report.create('html', {dir: coverageOptions.htmlReport}).writeReport(collector, true);
       }
 
       // check if a cobertura report should be generated


### PR DESCRIPTION
Hi,

I noticed that you originally had the sync of all reports in qunit.js (lines 94-106), but then over wrote it. When I run the plugin and try for an HTML report, it ends at the opening <body> tag. If I include the sync as true on the report, it works for me. I'm not sure if you intended to remove it or not, and if there was another reason. 

This request only covers HTML report.

Cheers,
Scott
