### PR TITLE
should not use a new collector on each new coverage event

### DIFF
--- a/tasks/qunit.js
+++ b/tasks/qunit.js
@@ -18,6 +18,7 @@ module.exports = function(grunt) {
   var phantomjs = require('grunt-lib-phantomjs-istanbul').init(grunt);
   var istanbul = require('istanbul');
   var instrumenter = new istanbul.Instrumenter();
+  var collector = new istanbul.Collector();
   var rimraf = require('rimraf');
 
   // Keep track of the last-started module, test and status.
@@ -81,7 +82,6 @@ module.exports = function(grunt) {
     if (coverage) {
       var Report = istanbul.Report;
       var Utils = istanbul.utils;
-      var collector = new istanbul.Collector();
       var coverageOptions = generalOptions.coverage;
 
       // add coverage information to the collector


### PR DESCRIPTION
Creating a new collector loses all the old information in the collector. If you keep the collector around, you get a full set of data at the end.

Effectively, this causes the index files generated in the coverage report to have info on all the files rather than just the last one run in that path, and it causes the summary at the end of the run (the one printed to STDOUT) to contain a full summary rather than just a summary of the last test run.
