### PR TITLE
Add thresholds for code coverage values

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,34 @@ If you're running your qunit tests with the help of a webserver,
 you have to point the coverage inspector to the physical path that
 is the base url of the qunit page you're running
 
+#### linesThresholdPct
+Type: `number`
+Optional
+
+Lines coverage percentage threshold to evaluate when running the build. If the actual
+coverage percentage is less than this value, the build will fail.
+
+#### statementsThresholdPct
+Type: `number`
+Optional
+
+Statements coverage percentage threshold to evaluate when running the build. If the actual
+coverage percentage is less than this value, the build will fail.
+
+#### functionsThresholdPct
+Type: `number`
+Optional
+
+Functions coverage percentage threshold to evaluate when running the build. If the actual
+coverage percentage is less than this value, the build will fail.
+
+#### branchesThresholdPct
+Type: `number`
+Optional
+
+Branches coverage percentage threshold to evaluate when running the build. If the actual
+coverage percentage is less than this value, the build will fail.
+
 ### Usage
 
 ```
@@ -93,7 +121,8 @@ is the base url of the qunit page you're running
           src: ['src/js/**/*.js'],
           instrumentedFiles: 'temp/',
           htmlReport: 'report/coverage',
-          coberturaReport: 'report/'
+          coberturaReport: 'report/',
+          linesThresholdPct: 85
         }
       },
       all: ['test/**/*.html']
@@ -102,7 +131,7 @@ is the base url of the qunit page you're running
 
 ### Warning
 There is currently a failure in the phantomjs npm module.
-If you're running into an "Phantom not found error", please check [this issue](https://github.com/Obvious/phantomjs/issues/15) 
+If you're running into an "Phantom not found error", please check [this issue](https://github.com/Obvious/phantomjs/issues/15)
 
 
 ---

--- a/tasks/qunit.js
+++ b/tasks/qunit.js
@@ -53,6 +53,12 @@ module.exports = function(grunt) {
     }
   };
 
+  var checkCodeCoverage = function(threshold, value, printName) {
+    if(threshold && value < threshold) {
+      grunt.warn('Code coverage for ' + printName + ' was below threshold (' + value + '% < ' + threshold + '%)');
+    }
+  };
+
   // QUnit hooks.
   phantomjs.on('qunit.moduleStart', function(name) {
     unfinished[name] = true;
@@ -281,6 +287,11 @@ module.exports = function(grunt) {
               grunt.log.ok('-  Statements: ' + status.coverage.statements.pct + '%');
               grunt.log.ok('-  Functions: ' + status.coverage.functions.pct + '%');
               grunt.log.ok('-  Branches: ' + status.coverage.branches.pct + '%');
+
+              checkCodeCoverage(generalOptions.coverage.linesThresholdPct, status.coverage.lines.pct, 'lines');
+              checkCodeCoverage(generalOptions.coverage.statementsThresholdPct, status.coverage.statements.pct, 'statements');
+              checkCodeCoverage(generalOptions.coverage.functionsThresholdPct, status.coverage.functions.pct, 'functions');
+              checkCodeCoverage(generalOptions.coverage.branchesThresholdPct, status.coverage.branches.pct, 'branches');
             }
           }
           // All done!


### PR DESCRIPTION
We wanted to be able to set thresholds for code coverage percentages and fail the build if coverage falls below that threshold. This Pull Request adds optional configurable thresholds for each of the coverage values emitted.
