### PR TITLE
Windows path is normalized in browser

### DIFF
--- a/tasks/qunit.js
+++ b/tasks/qunit.js
@@ -206,11 +206,11 @@ module.exports = function(grunt) {
       if (options.urls && options.coverage && options.coverage.baseUrl) {
         fileStorage = path.relative(options.coverage.baseUrl, filepath);
       }else{ //delivered via file - normalize file storage
-    		//files never have a domain hence allways start with /
-    		fileStorage = fileStorage.replace(/^\/?/g, "/");
-    		//all \ are replaced
-    		fileStorage = fileStorage.replace(/\\/g, "/");
-	    }
+        //files never have a domain hence allways start with /
+        fileStorage = fileStorage.replace(/^\/?/g, "/");
+        //all \ are replaced
+        fileStorage = fileStorage.replace(/\\/g, "/");
+      }
 
       // instrument the files that should be processed by istanbul
       if (options.coverage && options.coverage.instrumentedFiles) {


### PR DESCRIPTION
This should resolve #9.

Here too some issues arise in windows :-)
This normalization of fileStorage should fix them. 
It replicates the native browser URL normalization.

Would you also consider redeploying this project to npm?

Thanks, Florian Rüberg (florian.rueberg@gmail.com)
