### PR TITLE
Add support for clover coverage reports

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,12 @@ A folder where the Cobertura reports should be stored.
 
 A folder where the LCOV reports should be stored.
 
+#### cloverReport
+
+* Type: `string` [optional]
+
+A folder where the Clover reports should be stored.
+
 #### baseUrl
 
 * Type: `string` [optional]

--- a/package.json
+++ b/package.json
@@ -28,8 +28,8 @@
   },
   "dependencies": {
     "grunt-lib-phantomjs-istanbul": "~0.5.0",
-    "rimraf": "~2.2.6",
-    "istanbul": "~0.2.6"
+    "istanbul": "~0.2.7",
+    "rimraf": "~2.2.6"
   },
   "devDependencies": {
     "grunt-contrib-jshint": "~0.6.0",

--- a/tasks/qunit.js
+++ b/tasks/qunit.js
@@ -310,6 +310,11 @@ module.exports = function(grunt) {
                 Report.create('lcov', {dir: coverageOptions.lcovReport}).writeReport(collector, true);
               }
 
+              // check if a clover report should be generated
+              if (coverageOptions.cloverReport) {
+                Report.create('clover', {dir: coverageOptions.cloverReport}).writeReport(collector, true);
+              }
+
               // delete the instrumented files
               rimraf.sync(options.transport.instrumentedFiles);
 


### PR DESCRIPTION
This commit adds the ability to configure clover coverage reports, which are supported by istanbul.
