### PR TITLE
Normalize Windows paths when serving via webserver; bump version to 0.4.3.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "grunt-qunit-istanbul",
   "description": "Run QUnit unit tests in a headless PhantomJS instance and create coverage reports with istanbul.",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "homepage": "https://github.com/asciidisco/grunt-qunit-istanbul",
   "author": {
     "name": "Grunt Team",

--- a/tasks/qunit.js
+++ b/tasks/qunit.js
@@ -213,12 +213,12 @@ module.exports = function(grunt) {
       // check if files will be delivered by a webserver
       if (options.urls && options.coverage && options.coverage.baseUrl) {
         fileStorage = path.relative(options.coverage.baseUrl, filepath);
-      }else{ //delivered via file - normalize file storage
-        //files never have a domain hence allways start with /
+      } else { //delivered via file - normalize file storage
+        // files never have a domain hence always start with /
         fileStorage = fileStorage.replace(/^\/?/g, "/");
-        //all \ are replaced
-        fileStorage = fileStorage.replace(/\\/g, "/");
       }
+      // all \ are replaced
+      fileStorage = fileStorage.replace(/\\/g, "/");
 
       // instrument the files that should be processed by istanbul
       if (options.coverage && options.coverage.instrumentedFiles) {


### PR DESCRIPTION
This fixes #22.
