### PR TITLE
Provide `options.console` in task config

### DIFF
--- a/tasks/qunit.js
+++ b/tasks/qunit.js
@@ -165,7 +165,9 @@ module.exports = function(grunt) {
 
 
   // Pass-through console.log statements.
-  phantomjs.on('console', console.log.bind(console));
+  if(options.console) {
+    phantomjs.on('console', console.log.bind(console));
+  }
 
   grunt.registerMultiTask('qunit', 'Run QUnit unit tests in a headless PhantomJS instance.', function() {
     // Merge task-specific and/or target-specific options with these defaults.
@@ -177,6 +179,8 @@ module.exports = function(grunt) {
       // Explicit non-file URLs to test.
       urls: [],
       force: false,
+      // Connect phantomjs console output to grunt output
+      console: true,
       // Explicitly define all coverage options (as empty)
       coverage: {
         src: [],


### PR DESCRIPTION
Looks like this got missed when porting from `grunt-contrib-qunit`.  See: https://github.com/gruntjs/grunt-contrib-qunit/blob/master/tasks/qunit.js#L159
