### PR TITLE
Add prefix url option for server served assets

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,26 @@ A folder where the LCOV reports should be stored.
 
 A folder where the Clover reports should be stored.
 
+#### prefixUrl
+
+* Type: `string` [optional]
+* Default: ``
+
+If you're running your qunit tests with the help of a webserver, and there is
+a path that precedes the file system path of the assets.
+
+Example:
+```js
+// File system: './javascripts/index.js'
+// Webserver url: 'localhost:8080/assets/my-project/javascripts/index.js'
+
+{
+  baseUrl: '../', // Go up one level to `my-project`
+  prefixUrl: 'assets/' // Prefix used before the file path on the web url
+}
+```
+
+
 #### baseUrl
 
 * Type: `string` [optional]

--- a/tasks/qunit.js
+++ b/tasks/qunit.js
@@ -213,7 +213,7 @@ module.exports = function(grunt) {
 
       // check if files will be delivered by a webserver
       if (options.urls && options.coverage && options.coverage.baseUrl && options.coverage.instrumentedFiles) {
-        webStorage = path.relative(options.coverage.baseUrl, filepath).replace(/\\/g, "/");
+        webStorage = (options.coverage.prefixUrl || '') + path.relative(options.coverage.baseUrl, filepath).replace(/\\/g, "/");
         instrumentedFiles[webStorage] = instrumenter.instrumentSync(String(fs.readFileSync(filepath)), filepath);
       }
 


### PR DESCRIPTION
This adds a configuration property to be able to specify a prefix path for the resources when served from a web server.

The reason is we are trying to get coverage for mediawiki mobile frontend extension, and we need an extra option for the coverage instrumented files to get matched to the urls since our tests are served from a mediawiki server which prefixes the resources with a path (`w/`).

Example:

``` js
// File system: './javascripts/index.js'
// Webserver url: 'localhost:8080/assets/my-project/javascripts/index.js'

{
  baseUrl: '../', // Go up one level to `my-project`
  prefixUrl: 'assets/' // Prefix used before the file path on the web url
}
```

By adding this variable, we can specify that prefix and then the url and the fs path matches and the instrumented code gets used.
