### PR TITLE
Warn for errors from PhantomJS

### DIFF
--- a/tasks/qunit.js
+++ b/tasks/qunit.js
@@ -161,6 +161,7 @@ module.exports = function(grunt) {
 
   phantomjs.on('error.onError', function (msg, stackTrace) {
     grunt.event.emit('qunit.error.onError', msg, stackTrace);
+    grunt.log.warn('PhantomJS error:\n', msg, '\n', stackTrace);
   });
 
   grunt.registerMultiTask('qunit', 'Run QUnit unit tests in a headless PhantomJS instance.', function() {


### PR DESCRIPTION
This helps find issues where files failed to load, which usually causes the PhantomJS process to timeout, without any indicator of the underlying problem.

I'm suggesting the same patch for the gruntjs module: https://github.com/gruntjs/grunt-contrib-qunit/pull/96