### PR TITLE
Adding a new option coverage.tempDir to specify folder to store tempo…

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,12 @@ The js files you would like to end up in the coverage report.
 A temporary folder (that will be automatically generated and deleted after the
 test suite finishes) containing the instrumented source code.
 
+#### tempDir
+
+* Type: `string` [optional]
+
+A folder where the temporary coverage data files should be stored.
+
 #### reportOnFail
 
 * Type: `boolean` [optional]

--- a/tasks/qunit.js
+++ b/tasks/qunit.js
@@ -179,7 +179,8 @@ module.exports = function(grunt) {
       // Explicitly define all coverage options (as empty)
       coverage: {
         src: [],
-        disposeCollector: false
+        disposeCollector: false,
+        tempDir: __dirname + '/../temp'
       }
     });
 	
@@ -244,6 +245,8 @@ module.exports = function(grunt) {
             rimraf.sync(options.transport.instrumentedFiles);
           }
         }
+
+        var tempFileCoverage = path.normalize(options.coverage.tempDir + '/coverage.tmp');
 
         // write instrumented file information to an temporary file
         // and transport the info to phantom

--- a/tasks/qunit.js
+++ b/tasks/qunit.js
@@ -25,8 +25,6 @@ module.exports = function(grunt) {
   var options, currentModule, currentTest, status;
   // Keep track of the last-started test(s).
   var unfinished = {};
-  // Get temp file path for covarage
-  var tempFileCoverage = path.normalize(__dirname + '/../temp/coverage.tmp');
   // Get an asset file, local to the root of the project.
   var asset = path.join.bind(null, __dirname, '..');
 


### PR DESCRIPTION
…rary coverage data files. This is useful when you are using grunt concurrently say using Gradle.
