### PR TITLE
Replace QUnit.jsDump with QUnit.dump

### DIFF
--- a/phantomjs/bridge.js
+++ b/phantomjs/bridge.js
@@ -37,8 +37,8 @@
     if (!obj.result) {
       // Dumping large objects can be very slow, and the dump isn't used for
       // passing tests, so only dump if the test failed.
-      actual = QUnit.jsDump.parse(obj.actual);
-      expected = QUnit.jsDump.parse(obj.expected);
+      actual = QUnit.dump.parse(obj.actual);
+      expected = QUnit.dump.parse(obj.expected);
     }
     // Send it.
     sendMessage('qunit.log', obj.result, actual, expected, obj.message, obj.source);


### PR DESCRIPTION
Hello.
An error occurred when I'm using "grunt-qunit-istanbul" and QUnit 2.3.2.
I got a message below.

```txt
>> PhantomJS error:
>>  TypeError: undefined is not an object (evaluating 'QUnit.jsDump.parse')
```

In QUnit **2.x**, "QUnit.jsDump" is now replaced with "QUnit.dump".
https://qunitjs.com/upgrade-guide-2.x/#replace-qunit-jsdump-with-qunit-dump

> Originally jsDump was a standalone library imported into QUnit. It has since evolved further within the library. To reflect that, the property was renamed to QUnit.dump.parse. 

I edited `grunt-qunit-istanbul/phantomjs/bridge.js`, then my problem was resolved.
But it does not work on **Node.js: 0.8**.
https://travis-ci.org/sutara79/grunt-qunit-istanbul/

Do you have any good idea?
Thanks.